### PR TITLE
getSearchRange moved in FontTools

### DIFF
--- a/Lib/woffTools/__init__.py
+++ b/Lib/woffTools/__init__.py
@@ -13,8 +13,8 @@ import struct
 from fontTools.misc import sstruct
 from cStringIO import StringIO
 from xml.etree import ElementTree
-from fontTools.ttLib import TTFont, debugmsg, sortedTagList
-from fontTools.ttLib.sfnt import getSearchRange, calcChecksum, SFNTDirectoryEntry, \
+from fontTools.ttLib import TTFont, debugmsg, getSearchRange, sortedTagList
+from fontTools.ttLib.sfnt import calcChecksum, SFNTDirectoryEntry, \
     sfntDirectoryFormat, sfntDirectorySize, sfntDirectoryEntryFormat, sfntDirectoryEntrySize
 
 


### PR DESCRIPTION
`getSearchRange` moved out of the `sfnt` package up to the `ttLib` in FontTools commit `62dd7b2a0e0ab1109b56572c568ef5f582d8a0fd`, this pull request corrects the import call.