### PR TITLE
Support for newest version of fontTools

### DIFF
--- a/Lib/woffTools/__init__.py
+++ b/Lib/woffTools/__init__.py
@@ -10,7 +10,6 @@ more care.
 
 import zlib
 import struct
-from fontTools.misc import sstruct
 from cStringIO import StringIO
 from xml.etree import ElementTree
 from fontTools.ttLib import TTFont, debugmsg, sortedTagList
@@ -21,6 +20,11 @@ try:
     from fontTools.ttLib.sfnt import getSearchRange
 except ImportError:
     from fontTools.ttLib import getSearchRange
+
+try:
+    from fontTools.misc.sstruct import sstruct
+except ImportError:
+    from fontTools.misc import sstruct
 
 # -----------
 # Main Object

--- a/Lib/woffTools/__init__.py
+++ b/Lib/woffTools/__init__.py
@@ -14,9 +14,13 @@ from fontTools.misc import sstruct
 from cStringIO import StringIO
 from xml.etree import ElementTree
 from fontTools.ttLib import TTFont, debugmsg, sortedTagList
-from fontTools.ttLib.sfnt import getSearchRange, calcChecksum, SFNTDirectoryEntry, \
+from fontTools.ttLib.sfnt import calcChecksum, SFNTDirectoryEntry, \
     sfntDirectoryFormat, sfntDirectorySize, sfntDirectoryEntryFormat, sfntDirectoryEntrySize
 
+try:
+    from fontTools.ttLib.sfnt import getSearchRange
+except ImportError:
+    from fontTools.ttLib import getSearchRange
 
 # -----------
 # Main Object

--- a/Lib/woffTools/__init__.py
+++ b/Lib/woffTools/__init__.py
@@ -83,7 +83,7 @@ class WOFFFont(TTFont):
             self.privateData = None
 
     def __getattr__(self, attr):
-        if attr not in ("privateData", "metadata"):
+        if attr not in ("privateData", "metadata", "lazy"):
             raise AttributeError(attr)
         # metadata
         if attr == "metadata":
@@ -106,6 +106,8 @@ class WOFFFont(TTFont):
                     privateData = self.reader.privateData
                 self.privateData = privateData
             return self.privateData
+        elif attr == "lazy":
+            return False
         # fallback to None
         return None
 

--- a/Lib/woffTools/__init__.py
+++ b/Lib/woffTools/__init__.py
@@ -64,6 +64,7 @@ class WOFFFont(TTFont):
         self.minorVersion = 0
         self._metadata = None
         self._tableOrder = None
+        self._tableCache=None
 
         if file is not None:
             if not hasattr(file, "read"):


### PR DESCRIPTION
Looks like fontTools have moved getSearchRange and sstruct. As WOFFFont is a subclass of the FontTools TTFont object it now also need to have _tableCache and __getattr__ lazy.