### PR TITLE
Python 3 support and newest version of fontTools

### DIFF
--- a/Lib/woffTools/__init__.py
+++ b/Lib/woffTools/__init__.py
@@ -10,7 +10,6 @@ more care.
 
 import zlib
 import struct
-from fontTools.misc import sstruct
 from cStringIO import StringIO
 from xml.etree import ElementTree
 from fontTools.ttLib import TTFont, debugmsg, sortedTagList
@@ -21,6 +20,11 @@ try:
     from fontTools.ttLib.sfnt import getSearchRange
 except ImportError:
     from fontTools.ttLib import getSearchRange
+
+try:
+    from fontTools.misc.sstruct import sstruct
+except ImportError:
+    from fontTools.misc import sstruct
 
 # -----------
 # Main Object

--- a/Lib/woffTools/__init__.py
+++ b/Lib/woffTools/__init__.py
@@ -14,9 +14,13 @@ from fontTools.misc import sstruct
 from cStringIO import StringIO
 from xml.etree import ElementTree
 from fontTools.ttLib import TTFont, debugmsg, sortedTagList
-from fontTools.ttLib.sfnt import getSearchRange, calcChecksum, SFNTDirectoryEntry, \
+from fontTools.ttLib.sfnt import calcChecksum, SFNTDirectoryEntry, \
     sfntDirectoryFormat, sfntDirectorySize, sfntDirectoryEntryFormat, sfntDirectoryEntrySize
 
+try:
+    from fontTools.ttLib.sfnt import getSearchRange
+except ImportError:
+    from fontTools.ttLib import getSearchRange
 
 # -----------
 # Main Object

--- a/Lib/woffTools/__init__.py
+++ b/Lib/woffTools/__init__.py
@@ -83,7 +83,7 @@ class WOFFFont(TTFont):
             self.privateData = None
 
     def __getattr__(self, attr):
-        if attr not in ("privateData", "metadata"):
+        if attr not in ("privateData", "metadata", "lazy"):
             raise AttributeError(attr)
         # metadata
         if attr == "metadata":
@@ -106,6 +106,8 @@ class WOFFFont(TTFont):
                     privateData = self.reader.privateData
                 self.privateData = privateData
             return self.privateData
+        elif attr == "lazy":
+            return False
         # fallback to None
         return None
 

--- a/Lib/woffTools/__init__.py
+++ b/Lib/woffTools/__init__.py
@@ -64,6 +64,7 @@ class WOFFFont(TTFont):
         self.minorVersion = 0
         self._metadata = None
         self._tableOrder = None
+        self._tableCache=None
 
         if file is not None:
             if not hasattr(file, "read"):

--- a/Lib/woffTools/__init__.py
+++ b/Lib/woffTools/__init__.py
@@ -7,6 +7,7 @@ and WOFFWriter are also available for use outside of this module.
 Those objects are much faster than WOFFFont, but they require much
 more care.
 """
+from __future__ import print_function
 
 import zlib
 import struct
@@ -325,8 +326,8 @@ class WOFFReader(object):
             if self.checkChecksums > 1:
                 assert checksum == entry.origChecksum, "bad checksum for '%s' table" % tag
             elif checksum != entry.origChecksum:
-                print "bad checksum for '%s' table" % tag
-            print
+                print("bad checksum for '%s' table" % tag)
+            print()
         return data
 
     def getCompressedTableData(self, tag):

--- a/Lib/woffTools/__init__.py
+++ b/Lib/woffTools/__init__.py
@@ -9,9 +9,13 @@ more care.
 """
 from __future__ import print_function
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import range
+from builtins import object
 import zlib
 import struct
-from cStringIO import StringIO
+from io import StringIO
 from xml.etree import ElementTree
 from fontTools.ttLib import TTFont, debugmsg, sortedTagList
 from fontTools.ttLib.sfnt import calcChecksum, SFNTDirectoryEntry, \
@@ -78,7 +82,7 @@ class WOFFFont(TTFont):
             self.flavor = self.reader.flavor
             self.majorVersion = self.reader.majorVersion
             self.minorVersion = self.reader.minorVersion
-            self._tableOrder = self.reader.keys()
+            self._tableOrder = list(self.reader.keys())
         else:
             self._metadata = ElementTree.Element("metadata", version="1.0")
             self.privateData = None
@@ -167,7 +171,7 @@ class WOFFFont(TTFont):
         # if DSIG is to be written, the table order
         # must be completely specified. otherwise the
         # DSIG may not be valid after decoding the WOFF.
-        tags = self.keys()
+        tags = list(self.keys())
         if "GlyphOrder" in tags:
             tags.remove("GlyphOrder")
         if "DSIG" in tags:
@@ -306,7 +310,7 @@ class WOFFReader(object):
         of each table.
         """
         sorter = []
-        for tag, entry in self.tables.items():
+        for tag, entry in list(self.tables.items()):
             sorter.append((entry.offset, tag))
         order = [tag for offset, tag in sorted(sorter)]
         return order
@@ -695,7 +699,7 @@ def calcHeadCheckSumAdjustment(flavor, tables):
         sfntEntry.length = entry["length"]
         directory += sfntEntry.toString()
     # calculate the checkSumAdjustment
-    checkSums = [entry["checkSum"] for entry in tables.values()]
+    checkSums = [entry["checkSum"] for entry in list(tables.values())]
     checkSums.append(calcChecksum(directory))
     checkSumAdjustment = sum(checkSums)
     checkSumAdjustment = (0xB1B0AFBA - checkSumAdjustment) & 0xffffffff
@@ -925,8 +929,8 @@ def _testOverlaps(tableDirectory):
         edges[entry["tag"]] = (start, end)
     # look for overlaps
     overlaps = set()
-    for tag, (start, end) in edges.items():
-        for otherTag, (otherStart, otherEnd) in edges.items():
+    for tag, (start, end) in list(edges.items()):
+        for otherTag, (otherStart, otherEnd) in list(edges.items()):
             tag = tag.strip()
             otherTag = otherTag.strip()
             if tag == otherTag:

--- a/Lib/woffTools/test/test_validate.py
+++ b/Lib/woffTools/test/test_validate.py
@@ -696,7 +696,7 @@ def decompressedLengthTest1():
     header, directory, tableData = defaultTestData(header=True, directory=True, tableData=True)
     origData = testDataTableData
     compData = zlib.compress(origData)
-    for tag, (origData, compData) in tableData.items():
+    for tag, (origData, compData) in list(tableData.items()):
         tableData[tag] = (origData, zlib.compress(origData))
     updateDirectoryEntries(directory, tableData)
     return packTestHeader(header) + packTestDirectory(directory) + packTestTableData(directory, tableData)
@@ -711,7 +711,7 @@ def decompressedLengthTest2():
     header, directory, tableData = defaultTestData(header=True, directory=True, tableData=True)
     origData = testDataTableData
     compData = zlib.compress(origData)
-    for tag, (origData, compData) in tableData.items():
+    for tag, (origData, compData) in list(tableData.items()):
         tableData[tag] = (origData, zlib.compress(origData))
     updateDirectoryEntries(directory, tableData)
     for entry in directory:
@@ -952,7 +952,7 @@ def decompressionTest1():
     (False, 'PASS')
     """
     header, directory, tableData = defaultTestData(header=True, directory=True, tableData=True)
-    for tag, (origData, compData) in tableData.items():
+    for tag, (origData, compData) in list(tableData.items()):
         tableData[tag] = (origData, zlib.compress(compData))
     updateDirectoryEntries(directory, tableData)
     return packTestHeader(header) + packTestDirectory(directory) + packTestTableData(directory, tableData)
@@ -965,7 +965,7 @@ def decompressionTest2():
     (True, 'ERROR')
     """
     header, directory, tableData = defaultTestData(header=True, directory=True, tableData=True)
-    for tag, (origData, compData) in tableData.items():
+    for tag, (origData, compData) in list(tableData.items()):
         compData = "".join(reversed(zlib.compress(compData)))
         tableData[tag] = (origData, compData)
     updateDirectoryEntries(directory, tableData)

--- a/Lib/woffTools/tools/css.py
+++ b/Lib/woffTools/tools/css.py
@@ -9,6 +9,9 @@ from __future__ import print_function
 
 # import test
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import hex
 importErrors = []
 try:
     import numpy
@@ -31,7 +34,7 @@ if importErrors:
 # import
 
 import os
-import urllib
+import urllib.request, urllib.parse, urllib.error
 import optparse
 from woffTools import WOFFFont
 from woffTools.tools.support import findUniqueFileName
@@ -91,7 +94,7 @@ def makeFontFaceSrc(font, fileName, doLocalSrc=True):
             s = "/* " + s + " */"
         sources.append(s)
     # file name
-    s = "url(\"%s\")" % urllib.quote(fileName) # XXX:  format(\"woff\")
+    s = "url(\"%s\")" % urllib.parse.quote(fileName) # XXX:  format(\"woff\")
     sources.append(s)
     # write
     sources = "\n\t".join(sources)
@@ -195,7 +198,7 @@ def _skimNameIDs(font, priority):
         text = nameRecord.string
         nameIDs[nameID, platformID, platEncID, langID] = text
     for (nameID, platformID, platEncID, langID) in priority:
-        for (nID, pID, pEID, lID), text in nameIDs.items():
+        for (nID, pID, pEID, lID), text in list(nameIDs.items()):
             if nID != nameID:
                 continue
             if pID != platformID and platformID is not None:

--- a/Lib/woffTools/tools/css.py
+++ b/Lib/woffTools/tools/css.py
@@ -5,6 +5,7 @@ WOFF files. *makeFontFaceRule* is the only public function.
 This can also be used as a command line tool for generating
 CSS @font-face rules from WOFF files.
 """
+from __future__ import print_function
 
 # import test
 
@@ -24,7 +25,7 @@ except ImportError:
 
 if importErrors:
     import sys
-    print "Could not import needed module(s):", ", ".join(importErrors)
+    print("Could not import needed module(s):", ", ".join(importErrors))
     sys.exit()
 
 # import
@@ -259,14 +260,14 @@ def main():
     (options, args) = parser.parse_args()
     outputDirectory = options.outputDirectory
     if outputDirectory is not None and not os.path.exists(outputDirectory):
-        print "Directory does not exist:", outputDirectory
+        print("Directory does not exist:", outputDirectory)
         sys.exit()
     for fontPath in args:
         if not os.path.exists(fontPath):
-            print "File does not exist:", fontPath
+            print("File does not exist:", fontPath)
             sys.exit()
         else:
-            print "Creating CSS: %s..." % fontPath
+            print("Creating CSS: %s..." % fontPath)
             fontPath = fontPath.decode("utf-8")
             font = WOFFFont(fontPath)
             css = makeFontFaceRule(font, fontPath, doLocalSrc=options.doLocalSrc)

--- a/Lib/woffTools/tools/css.py
+++ b/Lib/woffTools/tools/css.py
@@ -207,6 +207,7 @@ def _skimNameIDs(font, priority):
                 continue
             if lID != langID and langID is not None:
                 continue
+            text = text.decode("utf-8")
             text = "".join([i for i in text if i != "\x00"])
             return text
 
@@ -256,7 +257,7 @@ tool should always be carefully checked.
 """
 
 def main():
-    parser = optparse.OptionParser(usage=usage, description=description, version="%prog 0.1beta")
+    parser = optparse.OptionParser(usage=usage, description=description, version="%prog 0.2")
     parser.add_option("-d", dest="outputDirectory", help="Output directory. The default is to output the CSS into the same directory as the font file.")
     parser.add_option("-o", dest="outputFileName", help="Output file name. The default is \"fontfilename.css\". If this file already exists a time stamp will be added to the file name.")
     parser.add_option("-l", action="store_true", dest="doLocalSrc", help="Write \"local\" instructions as part of the \"src\" descriptor.")
@@ -271,7 +272,8 @@ def main():
             sys.exit()
         else:
             print("Creating CSS: %s..." % fontPath)
-            fontPath = fontPath.decode("utf-8")
+            if hasattr(fontPath, "decode"):
+                fontPath = fontPath.decode("utf-8")
             font = WOFFFont(fontPath)
             css = makeFontFaceRule(font, fontPath, doLocalSrc=options.doLocalSrc)
             # make the output file name
@@ -289,7 +291,7 @@ def main():
             path = os.path.join(directory, fileName)
             path = findUniqueFileName(path)
             f = open(path, "wb")
-            f.write(css)
+            f.write(css.encode('utf-8'))
             f.close()
 
 if __name__ == "__main__":

--- a/Lib/woffTools/tools/info.py
+++ b/Lib/woffTools/tools/info.py
@@ -261,7 +261,7 @@ contents of one or more WOFF files.
 """
 
 def main():
-    parser = optparse.OptionParser(usage=usage, description=description, version="%prog 0.1beta")
+    parser = optparse.OptionParser(usage=usage, description=description, version="%prog 0.2")
     parser.add_option("-d", dest="outputDirectory", help="Output directory. The default is to output the report into the same directory as the font file.")
     parser.add_option("-o", dest="outputFileName", help="Output file name. The default is \"fontfilename_info.html\".")
     parser.set_defaults(excludeTests=[])
@@ -276,7 +276,8 @@ def main():
             sys.exit()
         else:
             print("Creating Info Report: %s..." % fontPath)
-            fontPath = fontPath.decode("utf-8")
+            if hasattr(fontPath, 'decode'):
+                fontPath = fontPath.decode("utf-8")
             font = WOFFFont(fontPath)
             html = reportInfo(font, fontPath)
             # make the output file name
@@ -294,7 +295,7 @@ def main():
             path = os.path.join(directory, fileName)
             path = findUniqueFileName(path)
             f = open(path, "wb")
-            f.write(html)
+            f.write(html.encode('utf-8'))
             f.close()
 
 if __name__ == "__main__":

--- a/Lib/woffTools/tools/info.py
+++ b/Lib/woffTools/tools/info.py
@@ -4,6 +4,7 @@ WOFF files. *reportInfo* is the only public function.
 
 This can also be used as a command line tool.
 """
+from __future__ import print_function
 
 # import test
 
@@ -23,7 +24,7 @@ except ImportError:
 
 if importErrors:
     import sys
-    print "Could not import needed module(s):", ", ".join(importErrors)
+    print("Could not import needed module(s):", ", ".join(importErrors))
     sys.exit()
 
 # import
@@ -263,14 +264,14 @@ def main():
     (options, args) = parser.parse_args()
     outputDirectory = options.outputDirectory
     if outputDirectory is not None and not os.path.exists(outputDirectory):
-        print "Directory does not exist:", outputDirectory
+        print("Directory does not exist:", outputDirectory)
         sys.exit()
     for fontPath in args:
         if not os.path.exists(fontPath):
-            print "File does not exist:", fontPath
+            print("File does not exist:", fontPath)
             sys.exit()
         else:
-            print "Creating Info Report: %s..." % fontPath
+            print("Creating Info Report: %s..." % fontPath)
             fontPath = fontPath.decode("utf-8")
             font = WOFFFont(fontPath)
             html = reportInfo(font, fontPath)

--- a/Lib/woffTools/tools/info.py
+++ b/Lib/woffTools/tools/info.py
@@ -8,6 +8,10 @@ from __future__ import print_function
 
 # import test
 
+from builtins import str
+from builtins import hex
+from builtins import chr
+from builtins import range
 importErrors = []
 try:
     import numpy
@@ -176,7 +180,7 @@ def writePrivateData(font, writer):
         src = font.privateData
         length = 16
         result = []
-        for i in xrange(0, len(src), length):
+        for i in range(0, len(src), length):
             s = src[i:i+length]
             hexa = []
             c = []

--- a/Lib/woffTools/tools/proof.py
+++ b/Lib/woffTools/tools/proof.py
@@ -163,7 +163,7 @@ contents of one or more WOFF files.
 defaultSampleText = "THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG. The quick brown fox jumps over the lazy dog."
 
 def main():
-    parser = optparse.OptionParser(usage=usage, description=description, version="%prog 0.1beta")
+    parser = optparse.OptionParser(usage=usage, description=description, version="%prog 0.2")
     parser.add_option("-d", dest="outputDirectory", help="Output directory. The default is to output the proof into the same directory as the font file.")
     parser.add_option("-o", dest="outputFileName", help="Output file name. The default is \"fontfilename_proof.html\".")
     parser.add_option("-t", dest="sampleTextFile", help="Sample text file. A file containing sample text to display. If not file is provided, The quick brown fox... will be used.")
@@ -187,7 +187,8 @@ def main():
             sys.exit()
         else:
             print("Creating Proof: %s..." % fontPath)
-            fontPath = fontPath.decode("utf-8")
+            if hasattr(fontPath, "decode"):
+                fontPath = fontPath.decode("utf-8")
             font = WOFFFont(fontPath)
             html = proofFont(font, fontPath, sampleText=sampleText)
             # make the output file name
@@ -205,7 +206,7 @@ def main():
             path = os.path.join(directory, fileName)
             path = findUniqueFileName(path)
             f = open(path, "wb")
-            f.write(html)
+            f.write(html.encode('utf-8'))
             f.close()
 
 if __name__ == "__main__":

--- a/Lib/woffTools/tools/proof.py
+++ b/Lib/woffTools/tools/proof.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 
 # import test
 
+from builtins import chr
 importErrors = []
 try:
     import numpy
@@ -104,7 +105,7 @@ def makeCharacterSet(font):
     categorizedCharacters = {}
     glyphNameToCharacter = {}
     for value, glyphName in sorted(mapping.items()):
-        character = unichr(value)
+        character = chr(value)
         # skip whitespace
         if not character.strip():
             continue

--- a/Lib/woffTools/tools/proof.py
+++ b/Lib/woffTools/tools/proof.py
@@ -5,6 +5,7 @@ WOFF files. *proofFont* is the only public function.
 This can also be used as a command line tool for generating
 proofs from WOFF files.
 """
+from __future__ import print_function
 
 # import test
 
@@ -24,7 +25,7 @@ except ImportError:
 
 if importErrors:
     import sys
-    print "Could not import needed module(s):", ", ".join(importErrors)
+    print("Could not import needed module(s):", ", ".join(importErrors))
     sys.exit()
 
 # import
@@ -169,22 +170,22 @@ def main():
     (options, args) = parser.parse_args()
     outputDirectory = options.outputDirectory
     if outputDirectory is not None and not os.path.exists(outputDirectory):
-        print "Directory does not exist:", outputDirectory
+        print("Directory does not exist:", outputDirectory)
         sys.exit()
     sampleText = defaultSampleText
     if options.sampleTextFile:
         if not os.path.exists(options.sampleTextFile):
-            print "Sample text file does not exist:", options.sampleTextFile
+            print("Sample text file does not exist:", options.sampleTextFile)
             sys.exit()
         f = open(options.sampleTextFile, "r")
         sampleText = f.read()
         f.close()
     for fontPath in args:
         if not os.path.exists(fontPath):
-            print "File does not exist:", fontPath
+            print("File does not exist:", fontPath)
             sys.exit()
         else:
-            print "Creating Proof: %s..." % fontPath
+            print("Creating Proof: %s..." % fontPath)
             fontPath = fontPath.decode("utf-8")
             font = WOFFFont(fontPath)
             html = proofFont(font, fontPath, sampleText=sampleText)

--- a/Lib/woffTools/tools/support.py
+++ b/Lib/woffTools/tools/support.py
@@ -4,7 +4,7 @@ from builtins import object
 import os
 import time
 from xml.etree import ElementTree
-from io import StringIO
+from io import BytesIO
 
 # ----------------------
 # Very Simple XML Writer
@@ -39,7 +39,7 @@ class XMLWriter(object):
             self._elements[-1].text += text
 
     def compile(self, encoding="utf-8"):
-        f = StringIO()
+        f = BytesIO()
         tree = ElementTree.ElementTree(self._root)
         indent(tree.getroot())
         tree.write(f, encoding=encoding)
@@ -390,7 +390,7 @@ def finishHTML(writer):
     writer.endtag("html")
     # get the text
     text = "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n"
-    text += writer.compile()
+    text += writer.compile().decode("utf-8")
     text = text.replace("c_l_a_s_s", "class")
     text = text.replace("a_p_o_s_t_r_o_p_h_e", "'")
     text = text.replace("l_e_s_s", "<")

--- a/Lib/woffTools/tools/support.py
+++ b/Lib/woffTools/tools/support.py
@@ -1,7 +1,10 @@
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
 import os
 import time
 from xml.etree import ElementTree
-from cStringIO import StringIO
+from io import StringIO
 
 # ----------------------
 # Very Simple XML Writer
@@ -361,7 +364,7 @@ def startHTML(title=None, cssReplacements={}):
     # write the css
     writer.begintag("style", type="text/css")
     css = defaultCSS
-    for before, after in cssReplacements.items():
+    for before, after in list(cssReplacements.items()):
         css = css.replace(before, after)
     writer.write(css)
     writer.endtag("style")

--- a/Lib/woffTools/tools/validate.py
+++ b/Lib/woffTools/tools/validate.py
@@ -6,6 +6,7 @@ A module for validating the the file structure of WOFF Files.
 
 This can also be used as a command line tool for validating WOFF files.
 """
+from __future__ import print_function
 
 # import
 
@@ -2474,17 +2475,17 @@ def main():
     options.outputFormat = "html"
     options.testGroups = None # don't expose this to the commandline. it's for testing only.
     if outputDirectory is not None and not os.path.exists(outputDirectory):
-        print "Directory does not exist:", outputDirectory
+        print("Directory does not exist:", outputDirectory)
         sys.exit()
     for fontPath in args:
         if not os.path.exists(fontPath):
-            print "File does not exist:", fontPath
+            print("File does not exist:", fontPath)
             sys.exit()
         else:
-            print "Testing: %s..." % fontPath
+            print("Testing: %s..." % fontPath)
             fontPath = fontPath.decode("utf-8")
             outputPath, report = validateFont(fontPath, options)
-            print "Wrote report to: %s" % outputPath
+            print("Wrote report to: %s" % outputPath)
 
 if __name__ == "__main__":
     main()

--- a/Lib/woffTools/tools/validate.py
+++ b/Lib/woffTools/tools/validate.py
@@ -7,9 +7,18 @@ A module for validating the the file structure of WOFF Files.
 This can also be used as a command line tool for validating WOFF files.
 """
 from __future__ import print_function
+from __future__ import division
 
 # import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import hex
+from builtins import range
+from past.builtins import basestring
+from builtins import object
+from past.utils import old_div
 import os
 import re
 import time
@@ -18,7 +27,7 @@ import struct
 import zlib
 import optparse
 import codecs
-from cStringIO import StringIO
+from io import StringIO
 from xml.etree import ElementTree
 from xml.parsers.expat import ExpatError
 
@@ -1319,7 +1328,7 @@ def _validateMetadataElement(element, spec, reporter, parentTree=[]):
     haveError = False
     # unknown attributes
     knownAttributes = []
-    for attrib in spec["requiredAttributes"].keys() + spec["recommendedAttributes"].keys() + spec["optionalAttributes"].keys():
+    for attrib in list(spec["requiredAttributes"].keys()) + list(spec["recommendedAttributes"].keys()) + list(spec["optionalAttributes"].keys()):
         attrib = _parseAttribute(attrib)
         knownAttributes.append(attrib)
     for attrib in sorted(element.attrib.keys()):
@@ -1354,7 +1363,7 @@ def _validateMetadataElement(element, spec, reporter, parentTree=[]):
             if e:
                 haveError = True
     # unknown child-elements
-    knownChildElements = spec["requiredChildElements"].keys() + spec["recommendedChildElements"].keys() + spec["optionalChildElements"].keys()
+    knownChildElements = list(spec["requiredChildElements"].keys()) + list(spec["recommendedChildElements"].keys()) + list(spec["optionalChildElements"].keys())
     for childElement in element:
         if childElement.tag not in knownChildElements:
            _logMetadataResult(
@@ -1653,7 +1662,7 @@ def padData(data):
     return data
 
 def sumDataULongs(data):
-    longs = struct.unpack(">%dL" % (len(data) / 4), data)
+    longs = struct.unpack(">%dL" % (old_div(len(data), 4)), data)
     value = sum(longs) % (2 ** 32)
     return value
 
@@ -1695,7 +1704,7 @@ def calcHeadChecksum(data):
     for tag, sfntEntry in sorted(sfntEntries.items()):
         sfntData += structPack(sfntDirectoryEntryFormat, sfntEntry)
     # calculate
-    checkSums = [entry["checkSum"] for entry in sfntEntries.values()]
+    checkSums = [entry["checkSum"] for entry in list(sfntEntries.values())]
     checkSums.append(sumDataULongs(sfntData))
     checkSum = sum(checkSums)
     checkSum = (0xB1B0AFBA - checkSum) & 0xffffffff
@@ -2276,7 +2285,7 @@ def startHTML(title=None, cssReplacements={}):
     # write the css
     writer.begintag("style", type="text/css")
     css = defaultCSS
-    for before, after in cssReplacements.items():
+    for before, after in list(cssReplacements.items()):
         css = css.replace(before, after)
     writer.write(css)
     writer.endtag("style")

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import sys
 from setuptools import setup
 
 try:
     import fontTools
 except:
-    print "*** Warning: woffTools requires FontTools, see:"
-    print "    fonttools.sf.net"
+    print("*** Warning: woffTools requires FontTools, see:")
+    print("    fonttools.sf.net")
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,13 @@ except:
 
 setup(
     name="woffTools",
-    version="0.1beta",
+    version="0.2",
     description="A set of tools for working with WOFF files.",
     author="Tal Leming",
     author_email="tal@typesupply.com",
     url="https://github.com/typesupply/woffTools",
     license="MIT",
     packages=[
-        "",
         "woffTools",
         "woffTools.tools",
         "woffTools.test"

--- a/woff-all
+++ b/woff-all
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 
+from __future__ import print_function
 doc = """woff-all [options] fontpath1 fontpath2"
 
 This tool runs woof-validate, woff-info, woff-proof
@@ -15,12 +16,12 @@ from woffTools.tools import proof
 from woffTools.tools import css
 
 if len(sys.argv) > 1 and sys.argv[1] == "-h":
-    print doc
+    print(doc)
     sys.exit()
 
 for i in sys.argv:
     if i.startswith("-") and not i == "-d":
-        print "Only the -d argument may be used with this tool."
+        print("Only the -d argument may be used with this tool.")
         sys.exit()
 
 modules = [validate, info, proof, css]


### PR DESCRIPTION
Support for running on both Python 2 and 3. Tested with Python 2.7 and Python 3.6 and they gives the same output:

`env PYTHONPATH=Lib/ python2.7 ./woff-all /tmp/woffTools/py2/f1.woff`
`env PYTHONPATH=Lib/ python3.6 ./woff-all /tmp/woffTools/py3/f1.woff`

    diff -r /tmp/woffTools/py2/f1_info.html /tmp/woffTools/py3/f1_info.html
    300c300
    < 					<td>/tmp/woffTools/py2</td>
    ---
    > 					<td>/tmp/woffTools/py3</td>
    diff -r /tmp/woffTools/py2/f1_proof.html /tmp/woffTools/py3/f1_proof.html
    358c358
    < 					<td>/tmp/woffTools/py2</td>
    ---
    > 					<td>/tmp/woffTools/py3</td>
    diff -r /tmp/woffTools/py2/f1_validate.html /tmp/woffTools/py3/f1_validate.html
    273c273
    < 					<td>/tmp/woffTools/py2</td>
    ---
    > 					<td>/tmp/woffTools/py3</td>

